### PR TITLE
Update tflint

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "aws" {
   enabled = true
-  version = "0.14.0"
+  version = "0.18.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ apply:
 .PHONY: lint
 lint:
 	@./scripts/with-env.sh tflint --init
-	@./scripts/with-env.sh tflint --module --loglevel=info
+	export TFLINT_LOG=INFO
+	@./scripts/with-env.sh tflint --module
 
 .PHONY: connect
 connect:


### PR DESCRIPTION
--loglevel is deprecated since v0.40.0. Not sure if setting TFLINT_LOG is even needed, but was unable to find any docs on that.
AWS plugin has to be updated to be compatible with new tflint version.